### PR TITLE
All Uppercased SyCL to SYCL in generate_makefiles.bash

### DIFF
--- a/generate_makefile.bash
+++ b/generate_makefile.bash
@@ -47,7 +47,7 @@ do
       KOKKOS_DEVICES="${KOKKOS_DEVICES},Serial"
       ;;
     --with-sycl)
-      KOKKOS_DEVICES="${KOKKOS_DEVICES},SyCL"
+      KOKKOS_DEVICES="${KOKKOS_DEVICES},SYCL"
       ;;
     --with-qthreads*)
       KOKKOS_DEVICES="${KOKKOS_DEVICES},Qthreads"


### PR DESCRIPTION
Hi Nevin,  This is just the one character fix we discussed on Slack yesterday. 