### PR TITLE
Added support for non-trivially copyable kernels under SYCL

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -195,6 +195,7 @@ void SYCLInternal::initialize(const cl::sycl::device& d) {
     // auto devices = cl::sycl::device::get_devices();
     m_queue = std::make_unique<cl::sycl::queue>(d);
     std::cout << SYCL::SYCLDevice(d) << '\n';
+    m_indirectKernel.emplace(IndirectKernelAllocator(*m_queue));
 
     /*
         // Query what compute capability architecture a kernel executes:
@@ -395,6 +396,8 @@ void SYCLInternal::finalize() {
     m_scratchSpace      = 0;
     m_scratchFlags      = 0;
   }
+
+  m_indirectKernel.reset();
   m_queue.reset();
 }
 

--- a/core/src/SYCL/Kokkos_SYCL_KernelLaunch.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_KernelLaunch.hpp
@@ -11,33 +11,63 @@ namespace Kokkos {
 namespace Experimental {
 namespace Impl {
 
-template <class Driver>
-void sycl_launch_bind(Driver tmp, cl::sycl::handler& cgh) {
-  cgh.parallel_for(
-      cl::sycl::range<1>(tmp.m_policy.end() - tmp.m_policy.begin()), tmp);
+template <typename Policy, typename Functor>
+void sycl_direct_launch(const Policy& policy, const Functor& functor) {
+  // Convenience references
+  const Kokkos::Experimental::SYCL& space = policy.space();
+  Kokkos::Experimental::Impl::SYCLInternal& instance =
+      *space.impl_internal_space_instance();
+  cl::sycl::queue& q = *instance.m_queue;
+
+  q.wait();
+
+  auto end   = policy.end();
+  auto begin = policy.begin();
+  cl::sycl::range<1> range(end - begin);
+
+  q.submit([&](cl::sycl::handler& cgh) {
+    cgh.parallel_for(range, [=](cl::sycl::item<1> item) {
+      int id = item.get_linear_id();
+      functor(id);
+    });
+  });
+
+  q.wait();
+}
+
+// Indirectly launch a functor by explicitly creating it in USM shared memory
+template <typename Policy, typename Functor>
+void sycl_indirect_launch(const Policy& policy, const Functor& functor) {
+  // Convenience references
+  const Kokkos::Experimental::SYCL& space = policy.space();
+  Kokkos::Experimental::Impl::SYCLInternal& instance =
+      *space.impl_internal_space_instance();
+  Kokkos::Experimental::Impl::SYCLInternal::IndirectKernelMemory& kernelMem =
+      *instance.m_indirectKernel;
+
+  // Allocate USM shared memory for the functor
+  kernelMem.resize(std::max(kernelMem.size(), sizeof(Functor)));
+
+  // Placement new a copy of functor into USM shared memory
+  //
+  // Store it in a unique_ptr to call its destructor on scope exit
+  std::unique_ptr<Functor, Kokkos::Impl::destruct_delete> kernelFunctorPtr(
+      new (kernelMem.data()) Functor(functor));
+
+  // Use reference_wrapper (because it is both trivially copyable and invocable)
+  // and launch it
+  sycl_direct_launch(policy, std::reference_wrapper(*kernelFunctorPtr));
 }
 
 template <class Driver>
 void sycl_launch(const Driver driver) {
-  isTriviallyCopyable<Driver>();
-  isTriviallyCopyable<decltype(driver.m_functor)>();
-  driver.m_policy.space().impl_internal_space_instance()->m_queue->wait();
-#ifndef SYCL_USE_BIND_LAUNCH
-  driver.m_policy.space().impl_internal_space_instance()->m_queue->submit(
-      [&](cl::sycl::handler& cgh) {
-        cgh.parallel_for(
-            cl::sycl::range<1>(driver.m_policy.end() - driver.m_policy.begin()),
-            [=](cl::sycl::item<1> item) {
-              int id = item.get_linear_id();
-              driver.m_functor(id);
-            });
-      });
-  driver.m_policy.space().impl_internal_space_instance()->m_queue->wait();
-#else
-  driver.m_policy.space().impl_internal_space_instance()->m_queue->submit(
-      std::bind(Kokkos::Experimental::Impl::sycl_launch_bind<Driver>, driver,
-                std::placeholders::_1));
-#endif
+  // if the functor is trivially copyable, we can launch it directly;
+  // otherwise, we will launch it indirectly via explicitly creating
+  // it in USM shared memory.
+  if constexpr (std::is_trivially_copyable_v<decltype(driver.m_functor)>)
+    sycl_direct_launch(driver.m_policy, driver.m_functor);
+  else
+    sycl_indirect_launch(driver.m_policy, driver.m_functor);
 }
 
 }  // namespace Impl
@@ -45,3 +75,4 @@ void sycl_launch(const Driver driver) {
 }  // namespace Kokkos
 
 #endif  // KOKKOS_SYCL_KERNELLAUNCH_HPP_
+

--- a/core/src/impl/Kokkos_Utilities.hpp
+++ b/core/src/impl/Kokkos_Utilities.hpp
@@ -474,6 +474,25 @@ emulate_fold_comma_operator(Ts&&...) noexcept {
 // </editor-fold> end Folding emulation }}}1
 //==============================================================================
 
+//==============================================================================
+// destruct_delete is a unique_ptr deleter for objects
+// created by placement new into already allocated memory
+// by only calling the destructor on the object.
+//
+// Because unique_ptr never calls its deleter with a nullptr value,
+// no need to check if p == nullptr.
+//
+// Note:  This differs in interface from std::default_delete in that the
+// function call operator is templated instead of the class, to make
+// it easier to use and disallow specialization.
+struct destruct_delete {
+  template <typename T>
+  KOKKOS_INLINE_FUNCTION constexpr void operator()(T* p) const noexcept {
+    p->~T();
+  }
+};
+//==============================================================================
+
 }  // namespace Impl
 }  // namespace Kokkos
 


### PR DESCRIPTION
When we have a functor
that is not trivially copyable it is explicitly
constructed by the host in USM shared memory before being passed
"by pointer" (inside a reference_wrapper) to SYCL parallel_for.

This is to address the limitation that SYCL
data types can only be implicitly copied to the device if they
are trivially copyable.