### PR TITLE
Use USM device memory for IndirectKernel

### DIFF
--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -195,7 +195,7 @@ void SYCLInternal::initialize(const cl::sycl::device& d) {
     // auto devices = cl::sycl::device::get_devices();
     m_queue = std::make_unique<cl::sycl::queue>(d);
     std::cout << SYCL::SYCLDevice(d) << '\n';
-    m_indirectKernel = IndirectKernel(*m_queue);
+    m_indirectKernelMem = IndirectKernelMem(*m_queue);
 
     /*
         // Query what compute capability architecture a kernel executes:
@@ -397,7 +397,7 @@ void SYCLInternal::finalize() {
     m_scratchFlags      = 0;
   }
 
-  m_indirectKernel = IndirectKernel();
+  m_indirectKernelMem = IndirectKernelMem();
   m_queue.reset();
 }
 

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -195,7 +195,7 @@ void SYCLInternal::initialize(const cl::sycl::device& d) {
     // auto devices = cl::sycl::device::get_devices();
     m_queue = std::make_unique<cl::sycl::queue>(d);
     std::cout << SYCL::SYCLDevice(d) << '\n';
-    m_indirectKernel.emplace(IndirectKernelAllocator(*m_queue));
+    m_indirectKernel.emplace(*m_queue);
 
     /*
         // Query what compute capability architecture a kernel executes:

--- a/core/src/SYCL/Kokkos_SYCL_Instance.cpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.cpp
@@ -195,7 +195,7 @@ void SYCLInternal::initialize(const cl::sycl::device& d) {
     // auto devices = cl::sycl::device::get_devices();
     m_queue = std::make_unique<cl::sycl::queue>(d);
     std::cout << SYCL::SYCLDevice(d) << '\n';
-    m_indirectKernel.emplace(*m_queue);
+    m_indirectKernel = IndirectKernel(*m_queue);
 
     /*
         // Query what compute capability architecture a kernel executes:
@@ -397,7 +397,7 @@ void SYCLInternal::finalize() {
     m_scratchFlags      = 0;
   }
 
-  m_indirectKernel.reset();
+  m_indirectKernel = IndirectKernel();
   m_queue.reset();
 }
 

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -35,17 +35,100 @@ class SYCLInternal {
 
   std::unique_ptr<cl::sycl::queue> m_queue;
 
+  // USMObject is a reusable buffer for a single object
+  // in USM memory
+  template <sycl::usm::alloc Kind>
+  class USMObject {
+   public:
+    static constexpr sycl::usm::alloc kind = Kind;
+
+    USMObject(USMObject const&) = delete;
+    USMObject(USMObject&&)      = delete;
+    USMObject& operator=(USMObject&&) = delete;
+    USMObject& operator=(USMObject const&) = delete;
+
+    explicit USMObject(sycl::queue q) noexcept : m_q(std::move(q)) {}
+    ~USMObject() { sycl::free(m_data, m_q); }
+
+    sycl::queue queue() const noexcept { return m_q; }
+
+    void* data() noexcept { return m_data; }
+    const void* data() const noexcept { return m_data; }
+
+    size_t capacity() const noexcept { return m_capacity; }
+
+    // reserve() allocates space for at least n bytes
+    // returns the new capacity
+    size_t reserve(size_t n) {
+      if (m_capacity < n) {
+        void* malloced = sycl::malloc(n, m_q, kind);
+        if (!malloced) throw std::bad_alloc();
+        sycl::free(m_data, m_q);
+        m_data     = malloced;
+        m_capacity = n;
+      }
+
+      return m_capacity;
+    }
+
+    // This will memcpy an object T into memory held by this object
+    // returns: a T* to that object
+    //
+    // Note:  it is UB to dereference this pointer with an object that is
+    // not an implicit-lifetime nor trivially-copyable type, but presumably much
+    // faster because we can use USM device memory
+    template <typename T>
+    T* memcpy_from(const T& t) {
+      reserve(sizeof(T));
+      sycl::event memcopied = m_q.memcpy(m_data, std::addressof(t), sizeof(T));
+      memcopied.wait();
+
+      return reinterpret_cast<T*>(m_data);
+    }
+
+    // This will copy-constuct an object T into memory held by this object
+    // returns: a unique_ptr<T, destruct_delete> that will call the
+    // destructor on the type when it goes out of scope.
+    //
+    // Note:  This will not work with USM device memory
+    template <typename T>
+    std::unique_ptr<T, Kokkos::Impl::destruct_delete> copy_construct_from(
+        const T& t) {
+      static_assert(kind != sycl::usm::alloc::device,
+                    "Cannot copy construct into USM device memory");
+
+      reserve(sizeof(T));
+      return std::unique_ptr<T, Kokkos::Impl::destruct_delete>(new (m_data)
+                                                                   T(t));
+    }
+
+    // Performs either memcpy (for USM device memory) and returns a T*
+    // (but is technically UB when dereferenced on an object that is not
+    // an implicit-lifetime nor trivially-copyable type
+    //
+    // or
+    //
+    // performs copy construction (for other USM memory types) and returns a
+    // unique_ptr<T, ...>
+    template <typename T>
+    auto copy_from(const T& t) {
+      if constexpr (sycl::usm::alloc::device == kind)
+        return memcpy_from(t);
+      else
+        return copy_construct_from(t);
+    }
+
+   private:
+    sycl::queue m_q;
+    void* m_data      = nullptr;
+    size_t m_capacity = 0;
+  };
+
   // An indirect kernel is one where the functor to be executed is explicitly
-  // created in USM shared memory before being executed, to get around the
+  // copied to USM device memory before being executed, to get around the
   // trivially copyable limitation of SYCL.
-  //
-  // m_indirectKernel just manages the memory as a reuseable buffer.  It is
-  // stored in an optional because the allocator contains a queue
-  using IndirectKernelAllocator =
-      sycl::usm_allocator<std::byte, sycl::usm::alloc::shared>;
-  using IndirectKernelMemory =
-      std::vector<IndirectKernelAllocator::value_type, IndirectKernelAllocator>;
-  using IndirectKernel = std::optional<IndirectKernelMemory>;
+  using IndirectKernelMemory = USMObject<sycl::usm::alloc::shared>;
+  using IndirectKernel       = std::optional<IndirectKernelMemory>;
   IndirectKernel m_indirectKernel;
 
   static int was_finalized;
@@ -54,12 +137,11 @@ class SYCLInternal {
 
   int verify_is_initialized(const char* const label) const;
 
-  int is_initialized() const {
-    return m_queue != nullptr;
-  }
+  int is_initialized() const { return m_queue != nullptr; }
 
   void initialize(const cl::sycl::device& d);
   void initialize(const cl::sycl::device_selector& s);
+
   void initialize(int sycl_device_id);
   void initialize();
   void finalize();

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -127,7 +127,7 @@ class SYCLInternal {
   // An indirect kernel is one where the functor to be executed is explicitly
   // copied to USM device memory before being executed, to get around the
   // trivially copyable limitation of SYCL.
-  using IndirectKernelMemory = USMObject<sycl::usm::alloc::shared>;
+  using IndirectKernelMemory = USMObject<sycl::usm::alloc::device>;
   using IndirectKernel       = std::optional<IndirectKernelMemory>;
   IndirectKernel m_indirectKernel;
 

--- a/core/src/SYCL/Kokkos_SYCL_Instance.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_Instance.hpp
@@ -61,10 +61,15 @@ class SYCLInternal {
     // returns the new capacity
     size_t reserve(size_t n) {
       if (m_capacity < n) {
-        void* malloced = sycl::malloc(n, m_q, kind);
-        if (!malloced) throw std::bad_alloc();
+        // First free what we have (in case malloc can reuse it)
         sycl::free(m_data, m_q);
-        m_data     = malloced;
+
+        m_data = sycl::malloc(n, m_q, kind);
+        if (!m_data) {
+          m_capacity = 0;
+          throw std::bad_alloc();
+        }
+
         m_capacity = n;
       }
 

--- a/core/src/SYCL/Kokkos_SYCL_KernelLaunch.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_KernelLaunch.hpp
@@ -42,8 +42,8 @@ void sycl_indirect_launch(const Policy& policy, const Functor& functor) {
   const Kokkos::Experimental::SYCL& space = policy.space();
   Kokkos::Experimental::Impl::SYCLInternal& instance =
       *space.impl_internal_space_instance();
-  Kokkos::Experimental::Impl::SYCLInternal::IndirectKernelMemory& kernelMem =
-      *instance.m_indirectKernel;
+  Kokkos::Experimental::Impl::SYCLInternal::IndirectKernel& kernelMem =
+      instance.m_indirectKernel;
 
   // Put a copy of the functor into USM
   //

--- a/core/src/SYCL/Kokkos_SYCL_KernelLaunch.hpp
+++ b/core/src/SYCL/Kokkos_SYCL_KernelLaunch.hpp
@@ -42,17 +42,17 @@ void sycl_indirect_launch(const Policy& policy, const Functor& functor) {
   const Kokkos::Experimental::SYCL& space = policy.space();
   Kokkos::Experimental::Impl::SYCLInternal& instance =
       *space.impl_internal_space_instance();
-  Kokkos::Experimental::Impl::SYCLInternal::IndirectKernel& kernelMem =
-      instance.m_indirectKernel;
+  Kokkos::Experimental::Impl::SYCLInternal::IndirectKernelMem&
+      indirectKernelMem = instance.m_indirectKernelMem;
 
   // Put a copy of the functor into USM
   //
-  // Note:  if sycl::usm::alloc::device == kernelMem.kind and functor
+  // Note:  if sycl::usm::alloc::device == indirectKernelMem.kind and functor
   // is neither an implicit-lifetime nor trivially-copyable type, dereferencing
-  // the pointer returned technically invokes UB.  This is done because USM device
-  // memory is presumably much faster than USM shared memory but we cannot
-  // copy construct into the former.
-  auto kernelFunctorPtr = kernelMem.copy_from(functor);
+  // the pointer returned technically invokes UB.  This is done because USM
+  // device memory is presumably much faster than USM shared memory but we
+  // cannot copy construct into the former.
+  auto kernelFunctorPtr = indirectKernelMem.copy_from(functor);
 
   // Use reference_wrapper (because it is both trivially copyable and invocable)
   // to wrap the dereferenced pointer and launch it


### PR DESCRIPTION
Replaced IndirectKernel from using a vector to a hand rolled implementation to be able to change the USM memory type from
shared to device, as the usm_allocator does not support USM device memory.

IndirectKernel now uses USM device memory and memcpy to copy the functor.  Note:  it is UB to dereference the returned pointer with an object that is not either an implicit-lifetime nor trivially-copyable type, but presumably it is much faster in practice because we can use USM device memory instead of USM shared memory for it.
